### PR TITLE
Introduce support for ordered Orders

### DIFF
--- a/query.go
+++ b/query.go
@@ -50,18 +50,40 @@ type Operator string
 // https://cube.dev/docs/@cubejs-client-core#order
 type Order string
 
+type OrderTuple struct {
+	Key   string
+	Order Order
+}
+
+func (t OrderTuple) MarshalJSON() ([]byte, error) {
+	return json.Marshal([]string{t.Key, string(t.Order)})
+}
+
+func (t *OrderTuple) UnmarshalJSON(byts []byte) error {
+	tmp := [2]string{}
+
+	err := json.Unmarshal(byts, &tmp)
+	if err != nil {
+		return fmt.Errorf("unmarshal bytes into string array: %w", err)
+	}
+
+	t.Key = tmp[0]
+	t.Order = Order(tmp[1])
+	return nil
+}
+
 type requestBody struct {
 	Query Query `json:"query"`
 }
 
 // Query represents a query that can be issued to a Cube server via the client.
 type Query struct {
-	Measures       []string         `json:"measures,omitempty"`
-	TimeDimensions []TimeDimension  `json:"timeDimensions,omitempty"`
-	Order          map[string]Order `json:"order,omitempty"`
-	Limit          int              `json:"limit,omitempty"`
-	Filters        []Filter         `json:"filters,omitempty"`
-	Dimensions     []string         `json:"dimensions,omitempty"`
+	Measures       []string        `json:"measures,omitempty"`
+	TimeDimensions []TimeDimension `json:"timeDimensions,omitempty"`
+	Order          []OrderTuple    `json:"order,omitempty"`
+	Limit          int             `json:"limit,omitempty"`
+	Filters        []Filter        `json:"filters,omitempty"`
+	Dimensions     []string        `json:"dimensions,omitempty"`
 }
 
 // https://cube.dev/docs/query-format#time-dimensions-format

--- a/query_test.go
+++ b/query_test.go
@@ -1,6 +1,7 @@
 package cube_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	cube "github.com/TernaryInc/cubejs-go"
@@ -40,6 +41,67 @@ func Test_DateRangeMarshalJSON(t *testing.T) {
 		} else {
 			assert.Equal(t, *tcase.expected, string(actual))
 		}
+	}
+}
+
+func Test_OrderTupleMarshalJSON(t *testing.T) {
+	var battery = []struct {
+		orderArray []cube.OrderTuple
+		expected   string
+	}{
+		{
+			[]cube.OrderTuple{{Key: "key", Order: cube.Order_Asc}},
+			`[["key","asc"]]`,
+		},
+		{
+			[]cube.OrderTuple{{Key: "key1", Order: cube.Order_Asc}, {Key: "key2", Order: cube.Order_Desc}},
+			`[["key1","asc"],["key2","desc"]]`,
+		},
+		{
+			nil,
+			`null`,
+		},
+		{
+			[]cube.OrderTuple{},
+			`[]`,
+		},
+	}
+
+	for _, tcase := range battery {
+		var actual, err = json.Marshal(tcase.orderArray)
+		assert.Nil(t, err)
+		assert.Equal(t, tcase.expected, string(actual))
+	}
+}
+
+func Test_OrderTupleUnmarshalJSON(t *testing.T) {
+	var battery = []struct {
+		jsonstr  string
+		expected []cube.OrderTuple
+	}{
+		{
+			`[["key","asc"]]`,
+			[]cube.OrderTuple{{Key: "key", Order: cube.Order_Asc}},
+		},
+		{
+			`[["key1","asc"],["key2","desc"]]`,
+			[]cube.OrderTuple{{Key: "key1", Order: cube.Order_Asc}, {Key: "key2", Order: cube.Order_Desc}},
+		},
+		{
+			`null`,
+			nil,
+		},
+		{
+			`[]`,
+			[]cube.OrderTuple{},
+		},
+	}
+
+	for _, tcase := range battery {
+		var actual []cube.OrderTuple
+		var err = json.Unmarshal([]byte(tcase.jsonstr), &actual)
+		assert.Nil(t, err)
+		assert.Equal(t, tcase.expected, actual)
 	}
 }
 


### PR DESCRIPTION
In this PR, @acham1 and I add support for ordered Orders.  See https://github.com/TernaryInc/cubejs-go/issues/1