### PR TITLE
Add timeout to http client requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -94,9 +94,12 @@ func (c *Client) Load(ctx context.Context, query Query, results interface{}) (Re
 
 		limiter.Take()
 
-		// TODO: Replace with a client with a sensible timeout
-		// https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779
-		response, err = http.DefaultClient.Do(req)
+		// Default timeout for queries is 10 minutes per cubejs documentation
+		// https://cube.dev/docs/config#queue-options
+		var netClient = &http.Client{
+  			Timeout: time.Minute * 10,
+		}
+		response, err = netClient.Do(req)
 		if err != nil {
 			return ResponseMetadata{}, fmt.Errorf("do request: %w", err)
 		}


### PR DESCRIPTION
Per the reference to Nathan Smith's [article](https://medium.com/@nate510/don-t-use-go-s-default-http-client-4804cb19f779), the `http.DefaultClient` has a timeout setting of 0, meaning no timeout. The effect of this is that all requests will wait infinitely for a response. Defining a custom `http.Client` allows for defining a specific maximum `Timeout`. Per the [cubejs documentation](https://cube.dev/docs/config#queue-options), the default timeout for queries is 10 minutes.