### PR TITLE
Allow TimeDimension.Granularity to be omitted

### DIFF
--- a/query.go
+++ b/query.go
@@ -90,7 +90,7 @@ type Query struct {
 type TimeDimension struct {
 	Dimension   string      `json:"dimension"`
 	DateRange   DateRange   `json:"dateRange"`
-	Granularity Granularity `json:"granularity"`
+	Granularity Granularity `json:"granularity,omitempty"`
 }
 
 // https://cube.dev/docs/@cubejs-client-core#order


### PR DESCRIPTION
When omitted, the TimeDimension is used only for filtering purposes, and is not actually grouped-by in the final data query or presented back to the user in the Result data. Without omitempty, leveraging this behavior is not possible.