### PR TITLE
Setup ci to run tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,25 @@
+name: Test
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: Test
+        run: go test -v ./...

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.17
 
       - name: Build
         run: go build -v ./...

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 
 - [Introduction](#introduction)
 - [Support](#support)
-- [Example](#example)
 
 ## Introduction
 
@@ -15,7 +14,3 @@
 ## Support
 
 We've intended to build the subset of functionality that we need at Ternary into the Cube client presented. We recognize that not all of the functionality available to the Javascript client has been ported, but we plan to expand feature support as find it necessary. Contributions are always welcome; see [Contributing](contributing.md).
-
-## Future Plans
-
-- Set up CI/CD with [GitHub Actions](https://gfgfddgleb.medium.com/how-to-test-your-go-code-with-github-actions-f15881d46089)


### PR DESCRIPTION
This PR completes the item from the future plan. The GitHub action passes in https://github.com/tuliren/cubejs-go/pull/1.
