### PR TITLE
Allow passing the `ungrouped` option

### DIFF
--- a/query.go
+++ b/query.go
@@ -84,6 +84,7 @@ type Query struct {
 	Limit          int             `json:"limit,omitempty"`
 	Filters        []Filter        `json:"filters,omitempty"`
 	Dimensions     []string        `json:"dimensions,omitempty"`
+	Ungrouped      bool            `json:"ungrouped"`
 }
 
 // https://cube.dev/docs/query-format#time-dimensions-format


### PR DESCRIPTION
Ungrouped queries don't perform any aggregation (e.g. SUM, COUNT etc.) this is valuable for retrieving data from the anomaly datasets, which offer points, rather than a timeseries that is meant to be connected by a line.

See [Cube documentation](https://cube.dev/docs/query-format) for information about `ungrouped`.